### PR TITLE
TimeReport - transparent error messages

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -9,7 +9,7 @@
  * - use google auth with token based Jira RESTful API vs. cleartext password
  */
 
-var BUILD = '0.21.2';
+var BUILD = '0.21.3';
 
 /** 
  * Add a nice menu option for the users.

--- a/Code.gs
+++ b/Code.gs
@@ -9,7 +9,7 @@
  * - use google auth with token based Jira RESTful API vs. cleartext password
  */
 
-var BUILD = '0.21.1';
+var BUILD = '0.21.2';
 
 /** 
  * Add a nice menu option for the users.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jira Sheet Tools
 
-[Jira](https://www.atlassian.com/software/jira) is a powerful and well established project management tool amoung small to enterprise businesses. Still we often end up using Google Sheets for some overview roadmaps, project dashboards and other purposes.
+[Jira](https://www.atlassian.com/software/jira) is a powerful and well established project management tool among small to enterprise businesses. Still we often end up using Google Sheets for some overview roadmaps, project dashboards and other purposes.
 
 With this Google Sheet Add-on the, called "[Jira Sheet Tools](https://chrome.google.com/webstore/detail/jira-sheet-tools/ncijnapilmmnebhbdanhkbbofofcniao)" available in the Google Add-On store from within Google Sheet, you can now take your sheet based reports with Jira information to the next level.
 

--- a/customFunctions.gs
+++ b/customFunctions.gs
@@ -14,7 +14,7 @@ function JST_EPICLABEL(TicketId) {
     throw new Error("{TicketId} can not be empty.");
   }
 
-  if(epicField.usable === false || epicField.label_key == null) {
+  if(undefined == epicField || epicField.usable === false || epicField.label_key == null) {
     throw new Error("Please configure your Jira Epic field first. Go to 'Jira Sheet Tools' -> 'Configure Custom Fields'");
   }
 

--- a/jiraCommon.gs
+++ b/jiraCommon.gs
@@ -378,7 +378,7 @@ function unifyIssueAttrib(attrib, data) {
       }
       
     } else {
-      debug.log('unifyIssueAttrib(%s) is custom field, but no format defined in customFields:%s.', attrib, customFields);
+      debug.info('unifyIssueAttrib(%s) is custom field, but no format defined in customFields:%s.', attrib, customFields);
       resp.value = data.fields[attrib] || data[attrib];
     }
 
@@ -524,7 +524,7 @@ function unifyIssueAttrib(attrib, data) {
       break;
 
     default:
-      debug.log('unifyIssueAttrib(' + attrib + ') no format defined yet.(01)');
+      debug.info('unifyIssueAttrib(' + attrib + ') no format defined yet.(01)');
       resp.value = data[attrib] || data.fields[attrib];
       break;
   }

--- a/jiraTicketInfo.gs
+++ b/jiraTicketInfo.gs
@@ -49,7 +49,7 @@ function refreshTickets() {
       rows.getCell(rowIdx, colIdx).setNote("This Jira ticket does not exist on " + getCfg('jira_url'));
     } else {
       // Jira returns all errors that occured in an array (if using the application/json mime type)
-      rows.getCell(rowIdx, colIdx).setNote("Jira Error: " + responseData.errorMessages.join(","));
+      rows.getCell(rowIdx, colIdx).setNote("Jira Error: " + responseData.errorMessages.join(",") || responseData.errorMessages);
     }
   };
 

--- a/jsLib.gs
+++ b/jsLib.gs
@@ -174,6 +174,7 @@ if (!Array.prototype.fill) {
   };
 }
 
+
 /**
  * @desc Converts time difference into human readable format.
  *       Returns difference in %d %h %m %s


### PR DESCRIPTION
Tweak transparency of possible api issues when retrieving individual worklogs for jira issues. Now adding the error message to the Jira issue row as a cell note to indicate issue occured.